### PR TITLE
Allow WooCommerce 302 response codes to proceed DEVJIRA-92835

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -314,7 +314,7 @@ class HttpClient
     protected function lookForErrors($parsedResponse)
     {
         // Any non-200/201/202 response code indicates an error.
-        if (!\in_array($this->response->getCode(), ['200', '201', '202'])) {
+        if (!\in_array($this->response->getCode(), ['200', '201', '202', '302'])) {
             $errors = !empty($parsedResponse['errors']) ? $parsedResponse['errors'] : $parsedResponse;
 
             if (!empty($errors[0])) {


### PR DESCRIPTION
### Description

The WooCommerce API will sometimes return a 302 response when creating webhooks, which will break the integration connection because it tries to throw an error for any non-2xx status. I've tested a WooCommerce account having this issue, and whitelisting 302 allows the connection to be established.

### Acceptance criteria

- [ ] Don't try to throw an error for 302 responses

**Team:** @ActiveCampaign/integration  
